### PR TITLE
Remove unused package

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   "dependencies": {
     "axios": "^1.7.7",
     "chalk": "^5.3.0",
-    "child_process": "^1.0.2",
     "cli-table3": "^0.6.5",
     "commander": "^12.1.0",
     "date-fns": "^4.1.0",


### PR DESCRIPTION
`child_process` isn't an npm package but it's added: https://www.npmjs.com/package/child_process

I think you mean `node:child_process` and the script probably works as it thinks it's that.